### PR TITLE
json_tricks fix

### DIFF
--- a/LIVVkit.yml
+++ b/LIVVkit.yml
@@ -12,7 +12,7 @@ dependencies:
 - matplotlib
 - nodejs
 - pip:
-  - json-tricks 
+  - json-tricks==3.11.0
   - sphinx
   - sphinx-js
   - sphinx-py3doc-enhanced-theme

--- a/livvkit/components/numerics_tests/ismip.py
+++ b/livvkit/components/numerics_tests/ismip.py
@@ -34,7 +34,6 @@ import six
 
 
 import os
-import json
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -42,6 +41,7 @@ import matplotlib.pyplot as plt
 import livvkit
 from livvkit.util.LIVVDict import LIVVDict
 from livvkit.util import elements
+from livvkit.util import functions
 
 
 case_color = {'bench': '#d7191c',
@@ -54,9 +54,8 @@ setup = None
 
 
 def set_up():
-    with open(os.path.join(os.path.dirname(__file__), 'ismip.json'), 'r') as f:
-        global setup
-        setup = json.load(f)
+    global setup
+    setup = functions.read_json(os.path.join(os.path.dirname(__file__), 'ismip.json'))
 
     for exp, size in [('ismip-hom-a', '005'), ('ismip-hom-c', '005'), ('ismip-hom-f', '000')]:
         recreate_file = os.path.join(livvkit.__path__[0], setup[exp]["data_dir"],

--- a/livvkit/util/functions.py
+++ b/livvkit/util/functions.py
@@ -32,7 +32,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import sys
-import json
 import errno
 import shutil
 import fnmatch
@@ -149,7 +148,7 @@ def read_json(file_path):
     config = {}
     try:
         with open(file_path, 'r') as f:
-            config = json.load(f)
+            config = json_tricks.load(f)
     except ValueError:
         print('    '+'!'*58)
         print('    Woops! Looks the JSON syntax is not valid in:')
@@ -175,7 +174,7 @@ def write_json(data, path, file_name):
     elif not os.path.exists(path):
         mkdir_p(path)
     with open(os.path.join(path, file_name), 'w') as f:
-        json_tricks.np.dump(data, f, indent=4, primitives=True, allow_nan=True)
+        json_tricks.dump(data, f, indent=4, primitives=True, allow_nan=True)
 
 
 def collect_cases(data_dir):

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
                        'scipy',
                        'netCDF4',
                        'matplotlib',
-                       'json-tricks'
+                       'json-tricks==3.11.0'
                        ],
 
       scripts=['livv'],


### PR DESCRIPTION
The newest version of json_tricks (3.11.0) changed the API slightly. This PR updates LIVVkit to work with it. 

Also, because json_tricks likes to break backwards compatibility, this pins the expected version to 3.11.0. 

Fixes #26 