### PR TITLE
LIVVKit 2.1.3 bugfix release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ target/
 /reg_bench/
 /reg_backup/
 
+# Pytest cache
+.pytest_cache/
+
+# Tox cache
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
 install: pip install tox-travis
 script: tox

--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ Software V&V
 * Verification
 * Performance
 
-Currently, LIVVkit is being developed and used in conjunction with the
-Community Ice Sheet Model
-([CISM](http://oceans11.lanl.gov/cism/documentation.html)), but is designed to
-be extensible to other models. 
-
-For further documentation view the 
+Currently, LIVVkit is being used and developed in conjunction with E3SM
+([Energy Exascale Earth System Model](https://e3sm.org/)) and CISM
+([Community Ice Sheet Model](https://cism.github.io/)), but is designed
+to be extensible to other models. For further documentation view the
 [full documentation](https://livvkit.github.io/Docs).
+
+**Users and contributors are welcome!** We’ll help you out –
+[open an issue on github](https://github.com/LIVVkit/LIVVkit/issues)
+to contact us for any reason.
 
   Installation 
 ================
@@ -38,12 +40,6 @@ The latest LIVVkit release can be installed via [pip](https://pip.pypa.io/en/sta
 
 ```sh
 pip install livvkit
-```
-
-or into a [conda](https://conda.io/docs/index.html) environment:
-
-```sh
-conda install -c jhkennedy livvkit
 ```
 
 Additionally, LIVVkit is released on github, and you can clone the source code:
@@ -68,60 +64,98 @@ livv -h
  Verification
 --------------
 
-In verification mode, LIVVkit analyzes and compares a regression testing dataset to a reference
-dataset, both of which are produced by CISM's built and test structure (BATS). For example, LIVVkit
-may analyze the dataset produced from a proposed CISM 2.0.6 release
-(~400MB; download [here](http://jhkennedy.org/LIVVkit/cism-2.0.6-tests.20160728.tgz)) 
-and compare it to the dataset produced from the CISM 2.0.0 release 
-(~400MB; download [here](http://jhkennedy.org/LIVVkit/cism-2.0.0-tests.20160728.tgz)).
+n verification mode, LIVVkit analyzes and compares a regression testing
+dataset to a reference dataset. For example, LIVVkit may analyze the dataset
+produced from a proposed CISM 2.0.6 release (~400MB; download
+[here](http://jhkennedy.org/LIVVkit/cism-2.0.6-tests.20160728.tgz)) and
+compare it to the dataset produced from the CISM 2.0.0 release (~400MB;
+download [here](http://jhkennedy.org/LIVVkit/cism-2.0.0-tests.20160728.tgz)).
+To run this example, first download the two aforementioned datasets to a
+directory, open a terminal, and navigate to your download directory.
+Then, un-tar the datasets:
 
 ```sh
-export TEST=cism-2.0.6-tests/titan-gnu/CISM_glissade/
-export REF=cism-2.0.0-tests/titan-gnu/CISM_glissade/
-
-livv -v $TEST $REF -o cism206v200
+tar -zxvf cism-2.0.0-tests.20160728.tgz
+tar -zxvf cism-2.0.6-tests.20160728.tgz
 ```
 
-This will produce a portable website in the `cism206v200` directory, which can be viewed by pointing
-your preferred browser to `cism206v200/index.html`. 
-
-*Note: recently we've been getting reports that Chrome will not display the javascript elements of
-our output website when viewed on the local file system. If you're not seeing any elements on the
-`cism206v200/index.html` page, try viewing with another browser (Firefox and Safari appear to be
-working; IE untested).*
-
- Validation
-------------
-
-LIVVkit's validation option allows you to execute validation extensions (internal or external) by
-pointing to one or more extension config file. LIVVkit ships with a extension template located in
-`livvkit/components/validation_tests/template/`. If you don't know the location of `livvkit`, run
-this command:
+For ease, export the path to the two dataset directories:
 
 ```sh
-python -c 'import livvkit; print(livvkit.__file__)'
+export REF=$PWD/cism-2.0.0-tests/titan-gnu/CISM_glissade
+export TEST=$PWD/cism-2.0.6-tests/titan-gnu/CISM_glissade
 ```
 
-which will output something like: 
+To run the suite, use:
 
 ```sh
-/home/joe/anaconda/envs/LIVVkit/lib/python3.6/site-packages/livvkit/__init__.py
+livv -v $TEST $REF -o cism206v200 -s
 ```
 
-Then, you can execute the extensions template like:
+LIVVkit will run the verification suite, report a summary of the results
+on the command line, produce an output website in the created `cism206v200`
+directory specified by the `-o/--out-dir` option, and launch an http server
+(the `-s/--serve option`) to easily view the output in your favorite web
+browser. LIVVkit will tell you the address to view the website at on the
+command line, which will typically look like
+http://0.0.0.0:8000/ver_test/index.html.
+
+
+ Validation, Extensions
+-----------------------
+
+LIVVkit is extensible to more in-depth or larger validation analyses.
+However, because these validation analyses are particularly data intensive,
+many of the observational and example model output files are much too
+large to distribute in the LIVVkit package. Therefore, we've developed a
+LIVVkit Extensions repository (LEX) which uses
+[git-lfs](https://git-lfs.github.com) (Git Large File Support) in order to
+distribute the required data. `git-lfs` can be installed either before or
+after cloning this repository, but it will be needed *before* downloading
+the required data. You can determine if you have `git-lfs` installed on
+your system by running this command:
 
 ```sh
-export LIVVKIT=/home/joe/anaconda/envs/LIVVkit/lib/python3.6/site-packages/livvkit
-
-livv -V $LIVVKIT/components/validation_tests/template/template.json -o val_test
+command -v git-lfs
 ```
 
-This will produce a portable website in the `val_test` directory, which can be viewed by pointing
-your preferred browser to `val_test/index.html`. 
+If `git-lfs` is not installed, you can install it by following the instructions here:
 
-*Note: recently we've been getting reports that Chrome will not display the javascript elements of
-our output website when viewed on the local file system. See our
-[FAQ](https://livvkit.github.io/Docs/faq.html) for a work-around.  
+https://git-lfs.github.com
+
+Once `git-lfs` is installed, clone and enter this repository:
+
+```sh
+git lfs clone https://code.ornl.gov/LIVVkit/lex.git
+cd lex
+```
+
+Each extension will have an associated JSON configuration file which will describe
+the extension's analysis code, data locations, and options. To see a list of
+available extensions, you can run this command:
+
+```sh
+find . -iname "*.json"
+```
+
+To execute any of these extensions, point `livv`
+to any of these extensions config file via the `-e/--extension` option (or the
+`-V/--validate` option). For example, to run the minimal example extension,
+place the output website in the `val_test` directory, and serve the output website
+you'd run this command:
+
+```sh
+livv -e example/example.json -o vv_test -s
+```
+
+*Note:* All the extension configurations files assume you are working from the
+top level `lex` directory. You *can* run any of these extensions from any
+directory, but you will need to edit the paths in the JSON configuration files so
+that `livv` can find the required files.
+
+Likewise, you can also apply these analyses to any new model run by adjusting
+the paths to point to your model run.
+
  
  More
 ------

--- a/docs/lex.rst
+++ b/docs/lex.rst
@@ -110,8 +110,14 @@ Developing a custom extension
 A template extension is provided as an absolute minimum working example
 in the ``examples/`` directory. To start developing a new extension, copy the
 ``examples/template.*`` files to a (possibly new) relevant directory, and change
-these file names to a descriptive name. These files will provide the basis for your
+these files' name to a descriptive name. These files will provide the basis for your
 new extension.
+
+.. note::
+
+    Importantly, the only things *required* for a new extension to run in LIVVkit
+    is a ``run()`` method in a ``py`` file and an ``json`` config file as described
+    below.
 
 template.py:
 ^^^^^^^^^^^^
@@ -124,10 +130,6 @@ function will then need to return a LIVVkit page element (:func:`livvkit.util.el
 which will contain a summary description of the extension (typically the extensions docstring),
 and all the page elements to display (see :mod:`livvkit.util.elements`).
 
-.. warning::
-
-    a little about elements... Additionally the top-level docstring should be used
-    for the extensions summary description.
 
 template.json:
 ^^^^^^^^^^^^^^

--- a/livvkit/__init__.py
+++ b/livvkit/__init__.py
@@ -39,7 +39,7 @@ import socket
 from livvkit import bundles
 from livvkit import resources
 
-__version_info__ = (2, 1, 2)
+__version_info__ = (2, 1, 3)
 __version__ = '.'.join(str(vi) for vi in __version_info__)
 
 cwd = os.getcwd()

--- a/livvkit/util/functions.py
+++ b/livvkit/util/functions.py
@@ -67,6 +67,24 @@ def mkdir_p(path):
             raise
 
 
+def merge_dicts(dict1, dict2):
+    """ Merge two dictionaries and return the result """
+    tmp = dict1.copy()
+    tmp.update(dict2)
+    return tmp
+
+
+def get_leaves(d):
+    """ Get the leaves of a nested dictionary """
+    leaves = []
+    for key, val in d.items():
+        if issubclass(type(val), dict):
+            leaves.append(get_leaves(val))
+        else:
+            return val
+    return leaves
+
+
 def parse_gptl(file_path, var_list):
     """
     Read a GPTL timing file and extract some data.

--- a/livvkit/util/functions.py
+++ b/livvkit/util/functions.py
@@ -74,17 +74,6 @@ def merge_dicts(dict1, dict2):
     return tmp
 
 
-def get_leaves(d):
-    """ Get the leaves of a nested dictionary """
-    leaves = []
-    for key, val in d.items():
-        if issubclass(type(val), dict):
-            leaves.append(get_leaves(val))
-        else:
-            return val
-    return leaves
-
-
 def parse_gptl(file_path, var_list):
     """
     Read a GPTL timing file and extract some data.

--- a/setup.py
+++ b/setup.py
@@ -44,16 +44,6 @@ with open(os.path.join(here, 'README.md'), 'r') as f:
 with open(os.path.join(here, 'livvkit', '__init__.py')) as f:
     init_file = f.read()
 
-# NOTE: Numpy really wants to build from source unless it's already installed,
-# which is slow and prone to failure This significantly make the build more
-# robust and much faster.
-try:
-    import numpy
-except ImportError:
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'numpy'])
-    numpy = importlib.import_module('numpy')
-    print('Installed numpy v{} via pip.'.format(numpy.__version__))
-
 setup(
       name='livvkit',
       version=re.search(r'{}\s*=\s*[(]([^)]*)[)]'.format('__version_info__'),
@@ -64,7 +54,7 @@ setup(
       long_description=long_desc,
       long_description_content_type='text/markdown',
 
-      url='http://github.com/LIVVkit/LIVVkit',
+      url='https://github.com/LIVVkit/LIVVkit',
 
       author='Joseph H. Kennedy et al.',
       author_email='kennedyjh@ornl.gov',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,6 +22,16 @@ def test_fn_mkdir_p_silent_existing(tmpdir):
     functions.mkdir_p(str(testdir))
 
 
+def test_fn_merge_dicts():
+    d1 = {'a': 0, 'b': 1, 'c': {'c0': 0, 'c1': 1, 'c2': 2}}
+    d2 = {'d': 'dee', 'e': 'ee', 'f': {'f0': 'eff', 'f1': 'eeff', 'f2': 2}}
+    truth = {'a': 0, 'b': 1, 'c': {'c0': 0, 'c1': 1, 'c2': 2},
+             'd': 'dee', 'e': 'ee', 'f': {'f0': 'eff', 'f1': 'eeff', 'f2': 2}}
+    test = functions.merge_dicts(d1, d2)
+
+    assert test == truth
+
+
 def test_fn_parse_gptl(ref_data):
     timing_file = ref_data.join('titan-gnu', 'CISM_glissade',
                                 'dome', 'dome', 's0', 'p1',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36
+envlist = py27, py35, py36
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
This bugfix release:

* Brings back the `merge_dicts` function used in `livv` that was removed previously
* Fixes some text in the README and documentation 
* No longer imports numpy in the setup.py file