### PR TITLE
More detailed logging and optionally supress warnings

### DIFF
--- a/livvkit/__main__.py
+++ b/livvkit/__main__.py
@@ -40,6 +40,11 @@ import livvkit
 from livvkit.util import options
 
 
+if not sys.warnoptions:
+    import warnings
+    warnings.simplefilter("ignore")
+
+
 def main(cl_args=None):
     """ Direct execution. """
 

--- a/livvkit/__main__.py
+++ b/livvkit/__main__.py
@@ -65,7 +65,6 @@ def main(cl_args=None):
     print("  User: " + livvkit.user)
     print("  OS Type: " + livvkit.os_type)
     print("  Machine: " + livvkit.machine)
-    print("  " + livvkit.comment)
 
     from livvkit.components import numerics
     from livvkit.components import verification

--- a/livvkit/util/functions.py
+++ b/livvkit/util/functions.py
@@ -222,8 +222,15 @@ def setup_output(cssd=None, jsd=None, imgd=None):
                 os.path.join(livvkit.index_dir, "index.html"))
     # Record when this data was recorded so we can make nice backups
     with open(os.path.join(livvkit.index_dir, "data.txt"), "w") as f:
-        f.write(livvkit.timestamp + "\n")
-        f.write(livvkit.comment)
+        f.write(livvkit.timestamp + '\n')
+        f.write('Call: livv ')
+        for arg in sys.argv[1:]:
+            f.write(arg)
+            f.write(' ')
+        f.write('\n')
+        f.write("User: " + livvkit.user + '\n')
+        f.write("OS Type: " + livvkit.os_type + '\n')
+        f.write("Machine: " + livvkit.machine + '\n')
 
     # Make a directory to keep log files
     mkdir_p(os.path.join(livvkit.index_dir, 'logs'))

--- a/livvkit/util/functions.py
+++ b/livvkit/util/functions.py
@@ -224,3 +224,6 @@ def setup_output(cssd=None, jsd=None, imgd=None):
     with open(os.path.join(livvkit.index_dir, "data.txt"), "w") as f:
         f.write(livvkit.timestamp + "\n")
         f.write(livvkit.comment)
+
+    # Make a directory to keep log files
+    mkdir_p(os.path.join(livvkit.index_dir, 'logs'))

--- a/livvkit/util/functions.py
+++ b/livvkit/util/functions.py
@@ -228,6 +228,7 @@ def setup_output(cssd=None, jsd=None, imgd=None):
             f.write(arg)
             f.write(' ')
         f.write('\n')
+        f.write('Version: ' + livvkit.__version__ + '\n')
         f.write("User: " + livvkit.user + '\n')
         f.write("OS Type: " + livvkit.os_type + '\n')
         f.write("Machine: " + livvkit.machine + '\n')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -130,6 +130,6 @@ def test_fn_setup_output(tmpdir):
     livvkit.index_dir = str(idir)
     functions.setup_output()
 
-    test = idir.join('data.txt').read_text('utf8').strip()
+    test = idir.join('data.txt').readlines()[0].strip()
 
     assert test == livvkit.timestamp


### PR DESCRIPTION
The `data.txt` file in the output directory now logs:
* calling arguments
* LIVVkit version
* user, OS, machine name

Also, this logs both the stdout and stderr of each forked analysis to a `logs` sub-directory in the output directory.

Finally, warnings a suppressed for runs unless requested by setting the python interpreter warning level. 

Fixes #15 