### PR TITLE
Include bibtex to html functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-sudo: false
 language: python
+dist: xenial
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 install: pip install tox-travis
 script: tox

--- a/LIVVkit.yml
+++ b/LIVVkit.yml
@@ -10,6 +10,7 @@ dependencies:
 - netcdf4
 - matplotlib
 - json_tricks==3.11.0
+- pybtex==0.21
 - nodejs
 - pytest
 - tox

--- a/livvkit/data/Evans2019.bib
+++ b/livvkit/data/Evans2019.bib
@@ -1,0 +1,10 @@
+@Article{gmd-2018-70,
+AUTHOR = {Evans, K. J. and Kennedy, J. H. and Lu, D. and Forrester, M. M. and Price, S. and Fyke, J. and Bennett, A. R. and Hoffman, M. J. and Tezaur, I. and Zender, C. S. and Vizcaíno, M.},
+TITLE = {LIVVkit 2.1: Automated and extensible ice sheet model validation},
+JOURNAL = {Geoscientific Model Development Discussions},
+VOLUME = {2018},
+YEAR = {2018},
+PAGES = {1--31},
+URL = {https://www.geosci-model-dev-discuss.net/gmd-2018-70/},
+DOI = {10.5194/gmd-2018-70}
+}

--- a/livvkit/data/Kennedy2017.bib
+++ b/livvkit/data/Kennedy2017.bib
@@ -1,0 +1,11 @@
+@article {Kennedy2017,
+    AUTHOR = {Kennedy, Joseph H. and Bennett, Andrew R. and Evans, Katherine J. and Price, Stephen and Hoffman, Matthew and Lipscomb, William H. and Fyke, Jeremy and Vargo, Lauren and Boghozian, Adrianna and Norman, Matthew and Worley, Patrick H.},
+    TITLE = {LIVVkit: An extensible, python-based, land ice verification and validation toolkit for ice sheet models},
+    JOURNAL = {Journal of Advances in Modeling Earth Systems},
+    VOLUME = {9},
+    NUMBER = {2},
+    ISSN = {1942-2466},
+    DOI = {10.1002/2017MS000916},
+    PAGES = {854--869},
+    YEAR = {2017},
+}

--- a/livvkit/util/bib.py
+++ b/livvkit/util/bib.py
@@ -116,7 +116,13 @@ def _bib2html_list(bib, style=None, backend=None):
     bibliography = pybtex.database.BibliographyData()
     for bib_file in bib:
         temp_bib = pybtex.database.parse_file(bib_file)
-        bibliography.add_entries(temp_bib.entries.items())
+        for key, entry in temp_bib.entries.items():
+            try:
+                bibliography.add_entry(key, entry)
+            except pybtex.database.BibliographyDataError:
+                # FIXME: should log this...
+                # Skip duplicate entries
+                continue
 
     formatted_bib = style.format_bibliography(bibliography)
 

--- a/livvkit/util/bib.py
+++ b/livvkit/util/bib.py
@@ -1,0 +1,134 @@
+# coding=utf-8
+# Copyright (c) 2015-2018, UT-BATTELLE, LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pybtex.database
+import pybtex.io
+
+from pybtex.backends.html import Backend as BaseBackend
+from pybtex.style.formatting.plain import Style as PlainStyle
+
+
+class HTMLBackend(BaseBackend):
+    def __init__(self, *args, **kwargs):
+        super(HTMLBackend, self).__init__(*args, **kwargs)
+        self._html = ''
+
+
+    def output(self, html):
+        self._html += html
+
+
+    def format_protected(self, text):
+        if text[:4] == 'http':
+            return self.format_href(text, text)
+        else:
+            return r'<span class="bibtex-protected">{}</span>'.format(text)
+
+
+    def write_prologue(self):
+        self.output('<div class="bibliography"><dl>')
+
+
+    def write_epilogue(self):
+        self.output('</dl></div>')
+
+
+    def _repr_html(self, formatted_bibliography):
+        self.write_prologue()
+        for entry in formatted_bibliography:
+            self.write_entry(entry.key, entry.label, entry.text.render(self))
+        self.write_epilogue()
+
+        return self._html.replace('\n', ' ').replace('\\url <a', '<a')
+
+
+# FIXME: For python 3.7+ only...
+# from functools import singledispatch
+# from collections.abc import Iterable
+#
+# # noinspection PyUnusedLocal
+# @singledispatch
+# def bib2html(bib, style=None, backend=None):
+#     raise NotImplementedError('I do not now how to convert a {} type to a bibliography'.format(type(bib)))
+def bib2html(bib, style=None, backend=None):
+    if isinstance(bib, str):
+        return _bib2html_string(bib, style=style, backend=backend)
+    if isinstance(bib, (list, set, tuple)):
+        return _bib2html_list(bib, style=style, backend=backend)
+    if isinstance(bib, pybtex.database.BibliographyData):
+        return _bib2html_bibdata(bib, style=style, backend=backend)
+    else:
+        raise NotImplementedError('I do not now how to convert a {} type to a bibliography'.format(type(bib)))
+
+
+# FIXME: For python 3.7+ only...
+# @bib2html.register
+# def _bib2html_string(bib: str, style=None, backend=None):
+def _bib2html_string(bib, style=None, backend=None):
+    if style is None:
+        style = PlainStyle()
+    if backend is None:
+        backend = HTMLBackend()
+
+    formatted_bib = style.format_bibliography(pybtex.database.parse_file(bib))
+
+    return backend._repr_html(formatted_bib)
+
+
+# FIXME: For python 3.7+ only...
+# @bib2html.register
+# def _bib2html_list(bib: Iterable, style=None, backend=None):
+def _bib2html_list(bib, style=None, backend=None):
+    if style is None:
+        style = PlainStyle()
+    if backend is None:
+        backend = HTMLBackend()
+
+    bibliography = pybtex.database.BibliographyData()
+    for bib_file in bib:
+        temp_bib = pybtex.database.parse_file(bib_file)
+        bibliography.add_entries(temp_bib.entries.items())
+
+    formatted_bib = style.format_bibliography(bibliography)
+
+    return backend._repr_html(formatted_bib)
+
+
+# FIXME: For python 3.7+ only...
+# @bib2html.register
+# def _bib2html_bibdata(bib: pybtex.database.BibliographyData, style=None, backend=None):
+def _bib2html_bibdata(bib, style=None, backend=None):
+    if style is None:
+        style = PlainStyle()
+    if backend is None:
+        backend = HTMLBackend()
+
+    formatted_bib = style.format_bibliography(bib)
+
+    return backend._repr_html(formatted_bib)

--- a/livvkit/util/bib.py
+++ b/livvkit/util/bib.py
@@ -27,6 +27,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, unicode_literals
+import six
+
 import pybtex.database
 import pybtex.io
 
@@ -77,7 +80,7 @@ class HTMLBackend(BaseBackend):
 # def bib2html(bib, style=None, backend=None):
 #     raise NotImplementedError('I do not now how to convert a {} type to a bibliography'.format(type(bib)))
 def bib2html(bib, style=None, backend=None):
-    if isinstance(bib, str):
+    if isinstance(bib, six.string_types):
         return _bib2html_string(bib, style=style, backend=backend)
     if isinstance(bib, (list, set, tuple)):
         return _bib2html_list(bib, style=style, backend=backend)

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
                    'Programming Language :: Python :: 3',
                    'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6',
+                   'Programming Language :: Python :: 3.7',
                    ],
 
       install_requires=['six',
@@ -79,7 +80,8 @@ setup(
                         'scipy',
                         'netCDF4',
                         'matplotlib',
-                        'json_tricks==3.11.0'
+                        'json_tricks==3.11.0',
+                        'pybtex==0.21',
                         ],
 
       packages=['livvkit',

--- a/tests/test_util_bib.py
+++ b/tests/test_util_bib.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+
+import os
+
+import pybtex.database
+
+import livvkit
+from livvkit.util import bib
+
+
+DATA_DIR = os.path.join(os.path.dirname(livvkit.__file__), 'data')
+
+KENNEDY2017_HTML = '<div class="bibliography"><dl><dt>1</dt> <dd>Joseph&nbsp;H. Kennedy, ' \
+                   'Andrew&nbsp;R. Bennett, Katherine&nbsp;J. Evans, Stephen Price, ' \
+                   'Matthew Hoffman, William&nbsp;H. Lipscomb, Jeremy Fyke, Lauren Vargo, ' \
+                   'Adrianna Boghozian, Matthew Norman, and Patrick&nbsp;H. Worley. ' \
+                   'Livvkit: an extensible, python-based, land ice verification and validation ' \
+                   'toolkit for ice sheet models. <em>Journal of Advances in Modeling Earth ' \
+                   'Systems</em>, 9(2):854–869, 2017. ' \
+                   '<a href="https://doi.org/10.1002/2017MS000916">doi:10.1002/2017MS000916</a>.' \
+                   '</dd> </dl></div>'
+
+KENNEDY2017_EVANS2019_HTML = '<div class="bibliography"><dl><dt>1</dt> <dd>K.&nbsp;J. Evans, ' \
+                             'J.&nbsp;H. Kennedy, D.&nbsp;Lu, M.&nbsp;M. Forrester, S.&nbsp;Price, ' \
+                             'J.&nbsp;Fyke, A.&nbsp;R. Bennett, M.&nbsp;J. Hoffman, I.&nbsp;Tezaur, ' \
+                             'C.&nbsp;S. Zender, and M.&nbsp;Vizcaíno. Livvkit 2.1: automated and ' \
+                             'extensible ice sheet model validation. <em>Geoscientific Model ' \
+                             'Development Discussions</em>, 2018:1–31, 2018. URL: ' \
+                             '<a href="https://www.geosci-model-dev-discuss.net/gmd-2018-70/">' \
+                             'https://www.geosci-model-dev-discuss.net/gmd-2018-70/</a>, ' \
+                             '<a href="https://doi.org/10.5194/gmd-2018-70">doi:10.5194/gmd-2018-70</a>.' \
+                             '</dd> <dt>2</dt> <dd>Joseph&nbsp;H. Kennedy, Andrew&nbsp;R. Bennett, ' \
+                             'Katherine&nbsp;J. Evans, Stephen Price, Matthew Hoffman, William&nbsp;H. ' \
+                             'Lipscomb, Jeremy Fyke, Lauren Vargo, Adrianna Boghozian, Matthew Norman, and ' \
+                             'Patrick&nbsp;H. Worley. Livvkit: an extensible, python-based, land ice ' \
+                             'verification and validation toolkit for ice sheet models. <em>Journal of ' \
+                             'Advances in Modeling Earth Systems</em>, 9(2):854–869, 2017. ' \
+                             '<a href="https://doi.org/10.1002/2017MS000916">doi:10.1002/2017MS000916</a>.' \
+                             '</dd> </dl></div>'
+
+
+def test_bib2html_str():
+    html = bib.bib2html(os.path.join(DATA_DIR, 'Kennedy2017.bib'))
+    assert html == KENNEDY2017_HTML
+
+
+def test_bib2html_list():
+    html = bib.bib2html([
+        os.path.join(DATA_DIR, 'Kennedy2017.bib'), os.path.join(DATA_DIR, 'Evans2019.bib')
+    ])
+    assert html == KENNEDY2017_EVANS2019_HTML
+
+
+def test_bib2html_set():
+    html = bib.bib2html({
+        os.path.join(DATA_DIR, 'Kennedy2017.bib'), os.path.join(DATA_DIR, 'Evans2019.bib')
+    })
+
+    assert html == KENNEDY2017_EVANS2019_HTML
+
+
+def test_bib2html_tuple():
+    html = bib.bib2html((
+        os.path.join(DATA_DIR, 'Kennedy2017.bib'), os.path.join(DATA_DIR, 'Evans2019.bib')
+    ))
+
+    assert html == KENNEDY2017_EVANS2019_HTML
+
+
+def test_bib2html_bibliographydata():
+    bibliography = pybtex.database.parse_file(os.path.join(DATA_DIR, 'Kennedy2017.bib'))
+
+    html = bib.bib2html(bibliography)
+
+    assert html == KENNEDY2017_HTML
+
+

--- a/tests/test_util_bib.py
+++ b/tests/test_util_bib.py
@@ -77,3 +77,8 @@ def test_bib2html_bibliographydata():
     assert html == KENNEDY2017_HTML
 
 
+def test_bib2html_duplicate_elements():
+    html = bib.bib2html([
+        os.path.join(DATA_DIR, 'Kennedy2017.bib'), os.path.join(DATA_DIR, 'Kennedy2017.bib')
+    ])
+    assert html == KENNEDY2017_HTML

--- a/tests/test_util_bib.py
+++ b/tests/test_util_bib.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 
-import os
+from __future__ import absolute_import, print_function, unicode_literals
 
+
+import os
 import pybtex.database
 
 import livvkit

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 commands = pytest
 deps =
     pytest
     requests
+    cython


### PR DESCRIPTION
Previously, this was handled in each LIVVkit extension independently. This provides a more flexible handling of bibtex in LIVVkit proper. 

Also, updates some of the testing to include python 3.7